### PR TITLE
add missing requirements for empty env

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,3 +12,7 @@ gradio
 screeninfo
 uiautomation
 dashscope
+torch
+torchvision
+transformers
+qwen-vl-utils


### PR DESCRIPTION
i had to manually pip install these additional 4 packages in the pr to get the `python app.py` to run in a blank conda env

```sh
conda create --name computer_use_ootb python=3.11
conda activate computer_use_ootb
git clone https://github.com/showlab/computer_use_ootb.git
cd computer_use_ootb
pip install -r dev-requirements.txt
python app.py
```

this works without error after adding those 4 packages to dev-requirements. 
