### PR TITLE
Fix

### DIFF
--- a/computer_use_demo/gui_agent/planner/local_vlm_planner.py
+++ b/computer_use_demo/gui_agent/planner/local_vlm_planner.py
@@ -25,7 +25,7 @@ SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>
 """
 
 MODEL_TO_HF_PATH = {
-    "qwen-vl-7b-instruct": "Qwen/Qwen2-VL-7B-Instruct",
+    "qwen2-vl-7b-instruct": "Qwen/Qwen2-VL-7B-Instruct",
     "qwen2-vl-2b-instruct": "Qwen/Qwen2-VL-2B-Instruct",
     "qwen2.5-vl-3b-instruct": "Qwen/Qwen2.5-VL-3B-Instruct",
     "qwen2.5-vl-7b-instruct": "Qwen/Qwen2.5-VL-7B-Instruct",

--- a/computer_use_demo/loop.py
+++ b/computer_use_demo/loop.py
@@ -134,7 +134,6 @@ def sampling_loop_sync(
             model=planner_model,
             provider=planner_provider,
             system_prompt_suffix=system_prompt_suffix,
-            api_key=api_key,
             api_response_callback=api_response_callback,
             selected_screen=selected_screen,
             output_callback=output_callback,


### PR DESCRIPTION
Fixed local models:

API_KEY causing error in local model initalization
wrong model name in local_vlm_planner for qwen-7b