### PR TITLE
feat: Add Groq provider support (free tier)

### DIFF
--- a/app.py
+++ b/app.py
@@ -300,6 +300,7 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
                         "llama-3.3-70b (Groq)",
                         "llama-3.1-8b (Groq)",
                         "llama-4-scout (Groq)",
+                        "qwen3-32b (Groq)",
                     ],
                     value="gpt-4o",
                     interactive=True,
@@ -510,7 +511,7 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
             raise ValueError(f"Model {model_selection} not supported")
 
         # Update the provider in state
-        state["planner_api_provider"] = provider_value
+        state["planner_provider"] = provider_value
 
         # Update api_key in state based on the provider
         if provider_value == "openai":
@@ -546,7 +547,7 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
         )
 
         logger.info(
-            f"Updated state: model={state['planner_model']}, provider={state['planner_api_provider']}, api_key={state['api_key']}"
+            f"Updated state: model={state['planner_model']}, provider={state['planner_provider']}, api_key={state['api_key']}"
         )
         return provider_update, api_key_update, actor_model_update
 
@@ -652,7 +653,7 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
                 image_preview = gr.Image(
                     value=initial_image_value,
                     label="Reference Initial State",
-                    height=260 - (318.75 - 280),
+                    height=221,  # Simplified from int(260 - (318.75 - 280))
                 )
                 hintbox = gr.Markdown("Task Hint: Selected options will appear here.")
 

--- a/app.py
+++ b/app.py
@@ -33,6 +33,7 @@ from computer_use_demo.loop import APIProvider, sampling_loop_sync
 
 from computer_use_demo.tools import ToolResult
 from computer_use_demo.tools.computer import get_screen_details
+
 SCREEN_NAMES, SELECTED_SCREEN_INDEX = get_screen_details()
 
 API_KEY_FILE = "./api_keys.json"
@@ -41,26 +42,27 @@ WARNING_TEXT = "⚠️ Security Alert: Do not provide access to sensitive accoun
 
 
 def setup_state(state):
-
     if "messages" not in state:
         state["messages"] = []
     # -------------------------------
     if "planner_model" not in state:
         state["planner_model"] = "gpt-4o"  # default
     if "actor_model" not in state:
-        state["actor_model"] = "ShowUI"    # default
+        state["actor_model"] = "ShowUI"  # default
     if "planner_provider" not in state:
         state["planner_provider"] = "openai"  # default
     if "actor_provider" not in state:
-        state["actor_provider"] = "local"    # default
+        state["actor_provider"] = "local"  # default
 
-     # Fetch API keys from environment variables
-    if "openai_api_key" not in state: 
+    # Fetch API keys from environment variables
+    if "openai_api_key" not in state:
         state["openai_api_key"] = os.getenv("OPENAI_API_KEY", "")
     if "anthropic_api_key" not in state:
-        state["anthropic_api_key"] = os.getenv("ANTHROPIC_API_KEY", "")    
+        state["anthropic_api_key"] = os.getenv("ANTHROPIC_API_KEY", "")
     if "qwen_api_key" not in state:
         state["qwen_api_key"] = os.getenv("QWEN_API_KEY", "")
+    if "groq_api_key" not in state:
+        state["groq_api_key"] = os.getenv("GROQ_API_KEY", "")
     if "ui_tars_url" not in state:
         state["ui_tars_url"] = ""
 
@@ -72,17 +74,22 @@ def setup_state(state):
             state["planner_api_key"] = state["anthropic_api_key"]
         elif state["planner_provider"] == "qwen":
             state["planner_api_key"] = state["qwen_api_key"]
+        elif state["planner_provider"] == "groq":
+            state["planner_api_key"] = state["groq_api_key"]
         else:
             state["planner_api_key"] = ""
 
-    logger.info(f"loaded initial api_key for {state['planner_provider']}: {state['planner_api_key']}")
+    logger.info(
+        f"loaded initial api_key for {state['planner_provider']}: {state['planner_api_key']}"
+    )
 
     if not state["planner_api_key"]:
-        logger.warning("Planner API key not found. Please set it in the environment or paste in textbox.")
-
+        logger.warning(
+            "Planner API key not found. Please set it in the environment or paste in textbox."
+        )
 
     if "selected_screen" not in state:
-        state['selected_screen'] = SELECTED_SCREEN_INDEX if SCREEN_NAMES else 0
+        state["selected_screen"] = SELECTED_SCREEN_INDEX if SCREEN_NAMES else 0
 
     if "auth_validated" not in state:
         state["auth_validated"] = False
@@ -91,17 +98,25 @@ def setup_state(state):
     if "tools" not in state:
         state["tools"] = {}
     if "only_n_most_recent_images" not in state:
-        state["only_n_most_recent_images"] = 10 # 10
+        state["only_n_most_recent_images"] = 10  # 10
     if "custom_system_prompt" not in state:
         state["custom_system_prompt"] = ""
         # remove if want to use default system prompt
-        device_os_name = "Windows" if platform.system() == "Windows" else "Mac" if platform.system() == "Darwin" else "Linux"
-        state["custom_system_prompt"] += f"\n\nNOTE: you are operating a {device_os_name} machine"
+        device_os_name = (
+            "Windows"
+            if platform.system() == "Windows"
+            else "Mac"
+            if platform.system() == "Darwin"
+            else "Linux"
+        )
+        state["custom_system_prompt"] += (
+            f"\n\nNOTE: you are operating a {device_os_name} machine"
+        )
     if "hide_images" not in state:
         state["hide_images"] = False
-    if 'chatbot_messages' not in state:
-        state['chatbot_messages'] = []
-        
+    if "chatbot_messages" not in state:
+        state["chatbot_messages"] = []
+
     if "showui_config" not in state:
         state["showui_config"] = "Default"
     if "max_pixels" not in state:
@@ -132,7 +147,9 @@ def validate_auth(provider: APIProvider, api_key: str | None):
         if not os.environ.get("CLOUD_ML_REGION"):
             return "Set the CLOUD_ML_REGION environment variable to use the Vertex API."
         try:
-            google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+            google.auth.default(
+                scopes=["https://www.googleapis.com/auth/cloud-platform"]
+            )
         except DefaultCredentialsError:
             return "Your google cloud credentials are not set up correctly."
 
@@ -147,14 +164,14 @@ def _tool_output_callback(tool_output: ToolResult, tool_id: str, tool_state: dic
 
 
 def chatbot_output_callback(message, chatbot_state, hide_images=False, sender="bot"):
-    
-    def _render_message(message: str | BetaTextBlock | BetaToolUseBlock | ToolResult, hide_images=False):
-    
+    def _render_message(
+        message: str | BetaTextBlock | BetaToolUseBlock | ToolResult, hide_images=False
+    ):
         logger.info(f"_render_message: {str(message)[:100]}")
 
         if isinstance(message, str):
             return message
-        
+
         is_tool_result = not isinstance(message, str) and (
             isinstance(message, ToolResult)
             or message.__class__.__name__ == "ToolResult"
@@ -184,38 +201,41 @@ def chatbot_output_callback(message, chatbot_state, hide_images=False, sender="b
             return message.text
         elif isinstance(message, BetaToolUseBlock) or isinstance(message, ToolUseBlock):
             return f"Tool Use: {message.name}\nInput: {message.input}"
-        else:  
+        else:
             return message
-
 
     # processing Anthropic messages
     message = _render_message(message, hide_images)
-    
+
     if sender == "bot":
         chatbot_state.append((None, message))
     else:
         chatbot_state.append((message, None))
 
     # Create a concise version of the chatbot state for logging
-    concise_state = [(truncate_string(user_msg), truncate_string(bot_msg)) for user_msg, bot_msg in chatbot_state]
+    concise_state = [
+        (truncate_string(user_msg), truncate_string(bot_msg))
+        for user_msg, bot_msg in chatbot_state
+    ]
     logger.info(f"chatbot_output_callback chatbot_state: {concise_state} (truncated)")
 
 
 def process_input(user_input, state):
-    
     setup_state(state)
 
     # Append the user message to state["messages"]
     state["messages"].append(
-            {
-                "role": "user",
-                "content": [TextBlock(type="text", text=user_input)],
-            }
-        )
+        {
+            "role": "user",
+            "content": [TextBlock(type="text", text=user_input)],
+        }
+    )
 
     # Append the user's message to chatbot_messages with None for the assistant's reply
-    state['chatbot_messages'].append((user_input, None))
-    yield state['chatbot_messages']  # Yield to update the chatbot UI with the user's message
+    state["chatbot_messages"].append((user_input, None))
+    yield state[
+        "chatbot_messages"
+    ]  # Yield to update the chatbot UI with the user's message
 
     # Run sampling_loop_sync with the chatbot_output_callback
     for loop_msg in sampling_loop_sync(
@@ -225,26 +245,32 @@ def process_input(user_input, state):
         actor_model=state["actor_model"],
         actor_provider=state["actor_provider"],
         messages=state["messages"],
-        output_callback=partial(chatbot_output_callback, chatbot_state=state['chatbot_messages'], hide_images=state["hide_images"]),
+        output_callback=partial(
+            chatbot_output_callback,
+            chatbot_state=state["chatbot_messages"],
+            hide_images=state["hide_images"],
+        ),
         tool_output_callback=partial(_tool_output_callback, tool_state=state["tools"]),
-        api_response_callback=partial(_api_response_callback, response_state=state["responses"]),
+        api_response_callback=partial(
+            _api_response_callback, response_state=state["responses"]
+        ),
         api_key=state["planner_api_key"],
         only_n_most_recent_images=state["only_n_most_recent_images"],
-        selected_screen=state['selected_screen'],
-        showui_max_pixels=state['max_pixels'],
-        showui_awq_4bit=state['awq_4bit']
-    ):  
+        selected_screen=state["selected_screen"],
+        showui_max_pixels=state["max_pixels"],
+        showui_awq_4bit=state["awq_4bit"],
+    ):
         if loop_msg is None:
-            yield state['chatbot_messages']
+            yield state["chatbot_messages"]
             logger.info("End of task. Close the loop.")
             break
-            
 
-        yield state['chatbot_messages']  # Yield the updated chatbot_messages to update the chatbot UI
+        yield state[
+            "chatbot_messages"
+        ]  # Yield the updated chatbot_messages to update the chatbot UI
 
 
 with gr.Blocks(theme=gr.themes.Soft()) as demo:
-    
     state = gr.State({})  # Use Gradio's state management
     setup_state(state.value)  # Initialize the state
 
@@ -254,22 +280,27 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
     if not os.getenv("HIDE_WARNING", False):
         gr.Markdown(WARNING_TEXT)
 
-    with gr.Accordion("Settings", open=True): 
+    with gr.Accordion("Settings", open=True):
         with gr.Row():
             with gr.Column():
                 # --------------------------
                 # Planner
                 planner_model = gr.Dropdown(
                     label="Planner Model",
-                    choices=["gpt-4o", 
-                             "gpt-4o-mini", 
-                             "qwen2-vl-max", 
-                             "qwen2-vl-2b (local)", 
-                             "qwen2-vl-7b (local)", 
-                             "qwen2-vl-2b (ssh)", 
-                             "qwen2-vl-7b (ssh)",
-                             "qwen2.5-vl-7b (ssh)", 
-                             "claude-3-5-sonnet-20241022"],
+                    choices=[
+                        "gpt-4o",
+                        "gpt-4o-mini",
+                        "qwen2-vl-max",
+                        "qwen2-vl-2b (local)",
+                        "qwen2-vl-7b (local)",
+                        "qwen2-vl-2b (ssh)",
+                        "qwen2-vl-7b (ssh)",
+                        "qwen2.5-vl-7b (ssh)",
+                        "claude-3-5-sonnet-20241022",
+                        "llama-3.3-70b (Groq)",
+                        "llama-3.1-8b (Groq)",
+                        "llama-4-scout (Groq)",
+                    ],
                     value="gpt-4o",
                     interactive=True,
                 )
@@ -322,9 +353,8 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
                     value=2,
                     interactive=True,
                 )
-    
-    with gr.Accordion("ShowUI Advanced Settings", open=False):  
-        
+
+    with gr.Accordion("ShowUI Advanced Settings", open=False):
         gr.Markdown("""
                     **Note:** Adjust these settings to fine-tune the resource (**memory** and **infer time**) and performance trade-offs of ShowUI. \\
                     Quantization model requires additional download. Please refer to [Computer Use OOTB - #ShowUI Advanced Settings guide](https://github.com/showlab/computer_use_ootb?tab=readme-ov-file#showui-advanced-settings) for preparation for this feature.
@@ -350,48 +380,53 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
                 )
             with gr.Column():
                 awq_4bit = gr.Checkbox(
-                    label="Enable AWQ-4bit Model",
-                    value=False,
-                    interactive=False
+                    label="Enable AWQ-4bit Model", value=False, interactive=False
                 )
-            
+
     # Define the merged dictionary with task mappings
     merged_dict = json.load(open("assets/examples/ootb_examples.json", "r"))
 
     def update_only_n_images(only_n_images_value, state):
         state["only_n_most_recent_images"] = only_n_images_value
-    
+
     # Callback to update the second dropdown based on the first selection
     def update_second_menu(selected_category):
         return gr.update(choices=list(merged_dict.get(selected_category, {}).keys()))
 
     # Callback to update the third dropdown based on the second selection
     def update_third_menu(selected_category, selected_option):
-        return gr.update(choices=list(merged_dict.get(selected_category, {}).get(selected_option, {}).keys()))
+        return gr.update(
+            choices=list(
+                merged_dict.get(selected_category, {}).get(selected_option, {}).keys()
+            )
+        )
 
     # Callback to update the textbox based on the third selection
     def update_textbox(selected_category, selected_option, selected_task):
-        task_data = merged_dict.get(selected_category, {}).get(selected_option, {}).get(selected_task, {})
+        task_data = (
+            merged_dict.get(selected_category, {})
+            .get(selected_option, {})
+            .get(selected_task, {})
+        )
         prompt = task_data.get("prompt", "")
         preview_image = task_data.get("initial_state", "")
         task_hint = "Task Hint: " + task_data.get("hint", "")
         return prompt, preview_image, task_hint
-    
+
     # Function to update the global variable when the dropdown changes
     def update_selected_screen(selected_screen_name, state):
         global SCREEN_NAMES
         global SELECTED_SCREEN_INDEX
         SELECTED_SCREEN_INDEX = SCREEN_NAMES.index(selected_screen_name)
         logger.info(f"Selected screen updated to: {SELECTED_SCREEN_INDEX}")
-        state['selected_screen'] = SELECTED_SCREEN_INDEX
-
+        state["selected_screen"] = SELECTED_SCREEN_INDEX
 
     def update_planner_model(model_selection, state):
         state["model"] = model_selection
         # Update planner_model
         state["planner_model"] = model_selection
         logger.info(f"Model updated to: {state['planner_model']}")
-        
+
         if model_selection == "qwen2-vl-max":
             provider_choices = ["qwen"]
             provider_value = "qwen"
@@ -402,7 +437,7 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
             actor_model_value = "ShowUI"
             actor_model_interactive = True
             api_key_type = "password"  # Display API key in password form
-        
+
         elif model_selection in ["qwen2-vl-2b (local)", "qwen2-vl-7b (local)"]:
             # Set provider to "openai", make it unchangeable
             provider_choices = ["local"]
@@ -446,9 +481,11 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
 
         elif model_selection == "claude-3-5-sonnet-20241022":
             # Provider can be any of the current choices except 'openai'
-            provider_choices = [option.value for option in APIProvider if option.value != "openai"]
+            provider_choices = [
+                option.value for option in APIProvider if option.value != "openai"
+            ]
             provider_value = "anthropic"  # Set default to 'anthropic'
-            state['actor_provider'] = "anthropic"
+            state["actor_provider"] = "anthropic"
             provider_interactive = True
             api_key_interactive = True
             api_key_placeholder = "claude API key"
@@ -457,12 +494,24 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
             actor_model_interactive = False
             api_key_type = "password"  # Display API key in password form
 
+        # Groq models (free tier, text-only - use with ShowUI actor)
+        elif "(Groq)" in model_selection:
+            provider_choices = ["groq"]
+            provider_value = "groq"
+            provider_interactive = False
+            api_key_interactive = True
+            api_key_type = "password"
+            api_key_placeholder = "Groq API key (free at console.groq.com)"
+            actor_model_choices = ["ShowUI", "UI-TARS"]
+            actor_model_value = "ShowUI"
+            actor_model_interactive = True
+
         else:
             raise ValueError(f"Model {model_selection} not supported")
 
         # Update the provider in state
         state["planner_api_provider"] = provider_value
-        
+
         # Update api_key in state based on the provider
         if provider_value == "openai":
             state["api_key"] = state.get("openai_api_key", "")
@@ -470,6 +519,8 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
             state["api_key"] = state.get("anthropic_api_key", "")
         elif provider_value == "qwen":
             state["api_key"] = state.get("qwen_api_key", "")
+        elif provider_value == "groq":
+            state["api_key"] = state.get("groq_api_key", "")
         elif provider_value == "local":
             state["api_key"] = ""
         # SSH的情况已经在上面处理过了，这里不需要重复处理
@@ -477,7 +528,7 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
         provider_update = gr.update(
             choices=provider_choices,
             value=provider_value,
-            interactive=provider_interactive
+            interactive=provider_interactive,
         )
 
         # Update the API Key textbox
@@ -485,18 +536,20 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
             placeholder=api_key_placeholder,
             value=state["api_key"],
             interactive=api_key_interactive,
-            type=api_key_type  # 添加 type 参数的更新
+            type=api_key_type,  # 添加 type 参数的更新
         )
 
         actor_model_update = gr.update(
             choices=actor_model_choices,
             value=actor_model_value,
-            interactive=actor_model_interactive
+            interactive=actor_model_interactive,
         )
 
-        logger.info(f"Updated state: model={state['planner_model']}, provider={state['planner_api_provider']}, api_key={state['api_key']}")
+        logger.info(
+            f"Updated state: model={state['planner_model']}, provider={state['planner_api_provider']}, api_key={state['api_key']}"
+        )
         return provider_update, api_key_update, actor_model_update
-    
+
     def update_actor_model(actor_model_selection, state):
         state["actor_model"] = actor_model_selection
         logger.info(f"Actor model updated to: {state['actor_model']}")
@@ -518,43 +571,42 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
 
     def update_system_prompt_suffix(system_prompt_suffix, state):
         state["custom_system_prompt"] = system_prompt_suffix
-        
+
     # When showui_config changes, we set the max_pixels and awq_4bit accordingly.
     def handle_showui_config_change(showui_config_val, state):
         if showui_config_val == "Default (Maximum)":
             state["max_pixels"] = 1344
             state["awq_4bit"] = False
             return (
-                gr.update(value=1344, interactive=False), 
-                gr.update(value=False, interactive=False)
+                gr.update(value=1344, interactive=False),
+                gr.update(value=False, interactive=False),
             )
         elif showui_config_val == "Medium":
             state["max_pixels"] = 1024
             state["awq_4bit"] = False
             return (
-                gr.update(value=1024, interactive=False), 
-                gr.update(value=False, interactive=False)
+                gr.update(value=1024, interactive=False),
+                gr.update(value=False, interactive=False),
             )
         elif showui_config_val == "Minimal":
             state["max_pixels"] = 1024
             state["awq_4bit"] = True
             return (
-                gr.update(value=1024, interactive=False), 
-                gr.update(value=True, interactive=False)
+                gr.update(value=1024, interactive=False),
+                gr.update(value=True, interactive=False),
             )
         elif showui_config_val == "Custom":
             # Do not overwrite the current user values, just make them interactive
-            return (
-                gr.update(interactive=True), 
-                gr.update(interactive=True)
-            )
+            return (gr.update(interactive=True), gr.update(interactive=True))
 
     def update_api_key(api_key_value, state):
         """Handle API key updates"""
         state["planner_api_key"] = api_key_value
         if state["planner_provider"] == "ssh":
             state["api_key"] = api_key_value
-        logger.info(f"API key updated: provider={state['planner_provider']}, api_key={state['api_key']}")
+        logger.info(
+            f"API key updated: provider={state['planner_provider']}, api_key={state['api_key']}"
+        )
 
     with gr.Accordion("Quick Start Prompt", open=False):  # open=False 表示默认收
         # Initialize Gradio interface with the dropdowns
@@ -562,29 +614,46 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
             # Set initial values
             initial_category = "Game Play"
             initial_second_options = list(merged_dict[initial_category].keys())
-            initial_third_options = list(merged_dict[initial_category][initial_second_options[0]].keys())
-            initial_text_value = merged_dict[initial_category][initial_second_options[0]][initial_third_options[0]]
+            initial_third_options = list(
+                merged_dict[initial_category][initial_second_options[0]].keys()
+            )
+            initial_text_value = merged_dict[initial_category][
+                initial_second_options[0]
+            ][initial_third_options[0]]
 
             with gr.Column(scale=2):
                 # First dropdown for Task Category
                 first_menu = gr.Dropdown(
-                    choices=list(merged_dict.keys()), label="Task Category", interactive=True, value=initial_category
+                    choices=list(merged_dict.keys()),
+                    label="Task Category",
+                    interactive=True,
+                    value=initial_category,
                 )
 
                 # Second dropdown for Software
                 second_menu = gr.Dropdown(
-                    choices=initial_second_options, label="Software", interactive=True, value=initial_second_options[0]
+                    choices=initial_second_options,
+                    label="Software",
+                    interactive=True,
+                    value=initial_second_options[0],
                 )
 
                 # Third dropdown for Task
                 third_menu = gr.Dropdown(
-                    choices=initial_third_options, label="Task", interactive=True, value=initial_third_options[0]
+                    choices=initial_third_options,
+                    label="Task",
+                    interactive=True,
+                    value=initial_third_options[0],
                     # choices=["Please select a task"]+initial_third_options, label="Task", interactive=True, value="Please select a task"
                 )
 
             with gr.Column(scale=1):
                 initial_image_value = "./assets/examples/init_states/honkai_star_rail_showui.png"  # default image path
-                image_preview = gr.Image(value=initial_image_value, label="Reference Initial State", height=260-(318.75-280))
+                image_preview = gr.Image(
+                    value=initial_image_value,
+                    label="Reference Initial State",
+                    height=260 - (318.75 - 280),
+                )
                 hintbox = gr.Markdown("Task Hint: Selected options will appear here.")
 
         # Textbox for displaying the mapped value
@@ -595,38 +664,63 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
     with gr.Row():
         # submit_button = gr.Button("Submit")  # Add submit button
         with gr.Column(scale=8):
-            chat_input = gr.Textbox(show_label=False, placeholder="Type a message to send to Computer Use OOTB...", container=False)
+            chat_input = gr.Textbox(
+                show_label=False,
+                placeholder="Type a message to send to Computer Use OOTB...",
+                container=False,
+            )
         with gr.Column(scale=1, min_width=50):
             submit_button = gr.Button(value="Send", variant="primary")
 
-    chatbot = gr.Chatbot(label="Chatbot History", type="tuples", autoscroll=True, height=580, group_consecutive_messages=False)
-    
-    planner_model.change(fn=update_planner_model, inputs=[planner_model, state], outputs=[planner_api_provider, planner_api_key, actor_model])
-    planner_api_provider.change(fn=update_api_key_placeholder, inputs=[planner_api_provider, planner_model], outputs=planner_api_key)
+    chatbot = gr.Chatbot(
+        label="Chatbot History",
+        autoscroll=True,
+        height=580,
+        group_consecutive_messages=False,
+    )
+
+    planner_model.change(
+        fn=update_planner_model,
+        inputs=[planner_model, state],
+        outputs=[planner_api_provider, planner_api_key, actor_model],
+    )
+    planner_api_provider.change(
+        fn=update_api_key_placeholder,
+        inputs=[planner_api_provider, planner_model],
+        outputs=planner_api_key,
+    )
     actor_model.change(fn=update_actor_model, inputs=[actor_model, state], outputs=None)
 
-    screen_selector.change(fn=update_selected_screen, inputs=[screen_selector, state], outputs=None)
-    only_n_images.change(fn=update_only_n_images, inputs=[only_n_images, state], outputs=None)
-    
+    screen_selector.change(
+        fn=update_selected_screen, inputs=[screen_selector, state], outputs=None
+    )
+    only_n_images.change(
+        fn=update_only_n_images, inputs=[only_n_images, state], outputs=None
+    )
+
     # When showui_config changes, we update max_pixels and awq_4bit automatically.
-    showui_config.change(fn=handle_showui_config_change, 
-                         inputs=[showui_config, state], 
-                         outputs=[max_pixels, awq_4bit])
-    
+    showui_config.change(
+        fn=handle_showui_config_change,
+        inputs=[showui_config, state],
+        outputs=[max_pixels, awq_4bit],
+    )
+
     # Link callbacks to update dropdowns based on selections
     first_menu.change(fn=update_second_menu, inputs=first_menu, outputs=second_menu)
-    second_menu.change(fn=update_third_menu, inputs=[first_menu, second_menu], outputs=third_menu)
-    third_menu.change(fn=update_textbox, inputs=[first_menu, second_menu, third_menu], outputs=[chat_input, image_preview, hintbox])
+    second_menu.change(
+        fn=update_third_menu, inputs=[first_menu, second_menu], outputs=third_menu
+    )
+    third_menu.change(
+        fn=update_textbox,
+        inputs=[first_menu, second_menu, third_menu],
+        outputs=[chat_input, image_preview, hintbox],
+    )
 
     # chat_input.submit(process_input, [chat_input, state], chatbot)
     submit_button.click(process_input, [chat_input, state], chatbot)
 
     planner_api_key.change(
-        fn=update_api_key,
-        inputs=[planner_api_key, state],
-        outputs=None
+        fn=update_api_key, inputs=[planner_api_key, state], outputs=None
     )
 
-demo.launch(share=False,
-            allowed_paths=["./"],
-            server_port=7888)  # TODO: allowed_paths
+demo.launch(share=False, allowed_paths=["./"], server_port=7888)  # TODO: allowed_paths

--- a/computer_use_demo/gui_agent/llm_utils/groq.py
+++ b/computer_use_demo/gui_agent/llm_utils/groq.py
@@ -6,15 +6,15 @@ Groq free tier limits (as of Jan 2026):
 - Llama 3.3 70B: 1,000 requests/day, 12,000 tokens/minute
 - Llama 3.1 8B: 14,400 requests/day, 6,000 tokens/minute
 - Llama 4 Scout: 1,000 requests/day, 30,000 tokens/minute
+- Qwen3 32B: 1,000 requests/day, 6,000 tokens/minute
 
 Note: Groq models are text-only (no vision support).
 For GUI automation, use Groq as planner with ShowUI as actor.
 """
 
 import os
-import logging
 import requests
-from computer_use_demo.gui_agent.llm_utils.llm_utils import is_image_path, encode_image
+from computer_use_demo.gui_agent.llm_utils.llm_utils import is_image_path
 
 
 # Groq API base URL (OpenAI-compatible)

--- a/computer_use_demo/gui_agent/llm_utils/groq.py
+++ b/computer_use_demo/gui_agent/llm_utils/groq.py
@@ -1,0 +1,167 @@
+"""
+Groq API integration for Computer Use OOTB.
+Groq provides an OpenAI-compatible API, making integration straightforward.
+
+Groq free tier limits (as of Jan 2026):
+- Llama 3.3 70B: 1,000 requests/day, 12,000 tokens/minute
+- Llama 3.1 8B: 14,400 requests/day, 6,000 tokens/minute
+- Llama 4 Scout: 1,000 requests/day, 30,000 tokens/minute
+
+Note: Groq models are text-only (no vision support).
+For GUI automation, use Groq as planner with ShowUI as actor.
+"""
+
+import os
+import logging
+import requests
+from computer_use_demo.gui_agent.llm_utils.llm_utils import is_image_path, encode_image
+
+
+# Groq API base URL (OpenAI-compatible)
+GROQ_API_BASE = "https://api.groq.com/openai/v1"
+
+# Groq model mappings
+GROQ_MODELS = {
+    "llama-3.3-70b": "llama-3.3-70b-versatile",
+    "llama-3.1-8b": "llama-3.1-8b-instant",
+    "llama-4-scout": "meta-llama/llama-4-scout-17b-16e-instruct",
+    "qwen3-32b": "qwen/qwen3-32b",
+}
+
+
+def run_groq_interleaved(
+    messages: list,
+    system: str,
+    llm: str,
+    api_key: str,
+    max_tokens: int = 256,
+    temperature: float = 0,
+):
+    """
+    Send chat completion request to Groq API.
+
+    Note: Groq does not support vision models, so images in messages
+    will be described as "[Screenshot attached]" placeholder.
+
+    Args:
+        messages: List of message content (text and image paths)
+        system: System prompt
+        llm: Model name (will be mapped to Groq model ID)
+        api_key: Groq API key
+        max_tokens: Maximum tokens to generate
+        temperature: Sampling temperature
+
+    Returns:
+        tuple: (response_text, token_usage)
+    """
+    api_key = api_key or os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "GROQ_API_KEY is not set. Get your free API key at https://console.groq.com/"
+        )
+
+    # Map model name to Groq model ID
+    model_id = GROQ_MODELS.get(llm, llm)
+
+    headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
+
+    final_messages = [{"role": "system", "content": system}]
+
+    # Process messages - Groq doesn't support images, so we handle them specially
+    if isinstance(messages, list):
+        for item in messages:
+            contents = []
+            if isinstance(item, dict):
+                for cnt in item["content"]:
+                    if isinstance(cnt, str):
+                        if is_image_path(cnt):
+                            # Groq doesn't support vision - add placeholder
+                            content = {
+                                "type": "text",
+                                "text": "[Screenshot attached - analyzing current screen state]",
+                            }
+                        else:
+                            content = {"type": "text", "text": cnt}
+                        contents.append(content)
+                message = {"role": item["role"], "content": contents}
+
+            elif isinstance(item, str):
+                if is_image_path(item):
+                    # Groq doesn't support vision - add placeholder
+                    contents.append(
+                        {
+                            "type": "text",
+                            "text": "[Screenshot attached - analyzing current screen state]",
+                        }
+                    )
+                    message = {"role": "user", "content": contents}
+                else:
+                    contents.append({"type": "text", "text": item})
+                    message = {"role": "user", "content": contents}
+            else:
+                contents.append({"type": "text", "text": str(item)})
+                message = {"role": "user", "content": contents}
+
+            final_messages.append(message)
+    elif isinstance(messages, str):
+        final_messages.append({"role": "user", "content": messages})
+
+    # Flatten content arrays to strings for Groq (simpler format)
+    for msg in final_messages:
+        if isinstance(msg["content"], list):
+            msg["content"] = " ".join(
+                c["text"] if isinstance(c, dict) and "text" in c else str(c)
+                for c in msg["content"]
+            )
+
+    print(f"[groq] sending messages to model: {model_id}")
+
+    payload = {
+        "model": model_id,
+        "messages": final_messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+
+    try:
+        response = requests.post(
+            f"{GROQ_API_BASE}/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=60,
+        )
+
+        result = response.json()
+
+        if response.status_code == 200:
+            text = result["choices"][0]["message"]["content"]
+            token_usage = int(result.get("usage", {}).get("total_tokens", 0))
+            return text, token_usage
+        else:
+            error_msg = result.get("error", {}).get("message", str(result))
+            print(f"[groq] Error: {error_msg}")
+            raise Exception(f"Groq API error: {error_msg}")
+
+    except requests.exceptions.Timeout:
+        raise Exception("Groq API request timed out")
+    except Exception as e:
+        print(f"[groq] Error in Groq API call: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    # Test the Groq API integration
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        print("Set GROQ_API_KEY environment variable to test")
+    else:
+        text, token_usage = run_groq_interleaved(
+            messages=["Hello, what model are you?"],
+            system="You are a helpful assistant.",
+            llm="llama-3.3-70b",
+            api_key=api_key,
+            max_tokens=100,
+            temperature=0,
+        )
+        print(f"Response: {text}")
+        print(f"Token usage: {token_usage}")

--- a/computer_use_demo/gui_agent/llm_utils/groq.py
+++ b/computer_use_demo/gui_agent/llm_utils/groq.py
@@ -2,7 +2,7 @@
 Groq API integration for Computer Use OOTB.
 Groq provides an OpenAI-compatible API, making integration straightforward.
 
-Groq free tier limits (as of Jan 2026):
+Groq free tier limits (see https://console.groq.com/docs/rate-limits for current limits):
 - Llama 3.3 70B: 1,000 requests/day, 12,000 tokens/minute
 - Llama 3.1 8B: 14,400 requests/day, 6,000 tokens/minute
 - Llama 4 Scout: 1,000 requests/day, 30,000 tokens/minute

--- a/computer_use_demo/gui_agent/planner/api_vlm_planner.py
+++ b/computer_use_demo/gui_agent/planner/api_vlm_planner.py
@@ -8,23 +8,35 @@ from typing import Any, cast, Dict, Callable
 
 from anthropic import Anthropic, AnthropicBedrock, AnthropicVertex, APIResponse
 from anthropic.types import TextBlock, ToolResultBlockParam
-from anthropic.types.beta import BetaMessage, BetaTextBlock, BetaToolUseBlock, BetaMessageParam
+from anthropic.types.beta import (
+    BetaMessage,
+    BetaTextBlock,
+    BetaToolUseBlock,
+    BetaMessageParam,
+)
 
 from computer_use_demo.tools.screen_capture import get_screenshot
-from computer_use_demo.gui_agent.llm_utils.oai import run_oai_interleaved, run_ssh_llm_interleaved
+from computer_use_demo.gui_agent.llm_utils.oai import (
+    run_oai_interleaved,
+    run_ssh_llm_interleaved,
+)
 from computer_use_demo.gui_agent.llm_utils.qwen import run_qwen
+from computer_use_demo.gui_agent.llm_utils.groq import run_groq_interleaved
 from computer_use_demo.gui_agent.llm_utils.llm_utils import extract_data, encode_image
-from computer_use_demo.tools.colorful_text import colorful_text_showui, colorful_text_vlm
+from computer_use_demo.tools.colorful_text import (
+    colorful_text_showui,
+    colorful_text_vlm,
+)
 
 
 class APIVLMPlanner:
     def __init__(
         self,
-        model: str, 
-        provider: str, 
-        system_prompt_suffix: str, 
+        model: str,
+        provider: str,
+        system_prompt_suffix: str,
         api_key: str,
-        output_callback: Callable, 
+        output_callback: Callable,
         api_response_callback: Callable,
         max_tokens: int = 4096,
         only_n_most_recent_images: int | None = None,
@@ -43,9 +55,16 @@ class APIVLMPlanner:
             self.model = "Qwen2-VL-7B-Instruct"
         elif model == "qwen2.5-vl-7b (ssh)":
             self.model = "Qwen2.5-VL-7B-Instruct"
+        # Groq models (free tier, text-only)
+        elif model == "llama-3.3-70b":
+            self.model = "llama-3.3-70b"
+        elif model == "llama-3.1-8b":
+            self.model = "llama-3.1-8b"
+        elif model == "llama-4-scout":
+            self.model = "llama-4-scout"
         else:
             raise ValueError(f"Model {model} not supported")
-        
+
         self.provider = provider
         self.system_prompt_suffix = system_prompt_suffix
         self.api_key = api_key
@@ -56,40 +75,43 @@ class APIVLMPlanner:
         self.output_callback = output_callback
         self.system_prompt = self._get_system_prompt() + self.system_prompt_suffix
 
-
         self.print_usage = print_usage
         self.total_token_usage = 0
         self.total_cost = 0
 
-           
     def __call__(self, messages: list):
-        
         # drop looping actions msg, byte image etc
-        planner_messages = _message_filter_callback(messages)  
+        planner_messages = _message_filter_callback(messages)
         print(f"filtered_messages: {planner_messages}")
 
         if self.only_n_most_recent_images:
-            _maybe_filter_to_n_most_recent_images(planner_messages, self.only_n_most_recent_images)
+            _maybe_filter_to_n_most_recent_images(
+                planner_messages, self.only_n_most_recent_images
+            )
 
         # Take a screenshot
-        screenshot, screenshot_path = get_screenshot(selected_screen=self.selected_screen)
+        screenshot, screenshot_path = get_screenshot(
+            selected_screen=self.selected_screen
+        )
         screenshot_path = str(screenshot_path)
         image_base64 = encode_image(screenshot_path)
-        self.output_callback(f'Screenshot for {colorful_text_vlm}:\n<img src="data:image/png;base64,{image_base64}">',
-                             sender="bot")
-        
+        self.output_callback(
+            f'Screenshot for {colorful_text_vlm}:\n<img src="data:image/png;base64,{image_base64}">',
+            sender="bot",
+        )
+
         # if isinstance(planner_messages[-1], dict):
         #     if not isinstance(planner_messages[-1]["content"], list):
         #         planner_messages[-1]["content"] = [planner_messages[-1]["content"]]
         #     planner_messages[-1]["content"].append(screenshot_path)
         # elif isinstance(planner_messages[-1], str):
         #     planner_messages[-1] = {"role": "user", "content": [{"type": "text", "text": planner_messages[-1]}]}
-        
+
         # append screenshot
         # planner_messages.append({"role": "user", "content": [{"type": "image", "image": screenshot_path}]})
-        
+
         planner_messages.append(screenshot_path)
-        
+
         print(f"Sending messages to VLMPlanner: {planner_messages}")
 
         if self.model == "gpt-4o-2024-11-20":
@@ -103,8 +125,10 @@ class APIVLMPlanner:
             )
             print(f"oai token usage: {token_usage}")
             self.total_token_usage += token_usage
-            self.total_cost += (token_usage * 0.15 / 1000000)  # https://openai.com/api/pricing/
-            
+            self.total_cost += (
+                token_usage * 0.15 / 1000000
+            )  # https://openai.com/api/pricing/
+
         elif self.model == "qwen2-vl-max":
             vlm_response, token_usage = run_qwen(
                 messages=planner_messages,
@@ -116,15 +140,19 @@ class APIVLMPlanner:
             )
             print(f"qwen token usage: {token_usage}")
             self.total_token_usage += token_usage
-            self.total_cost += (token_usage * 0.02 / 7.25 / 1000)  # 1USD=7.25CNY, https://help.aliyun.com/zh/dashscope/developer-reference/tongyi-qianwen-vl-plus-api
+            self.total_cost += (
+                token_usage * 0.02 / 7.25 / 1000
+            )  # 1USD=7.25CNY, https://help.aliyun.com/zh/dashscope/developer-reference/tongyi-qianwen-vl-plus-api
         elif "Qwen" in self.model:
             # 从api_key中解析host和port
             try:
                 ssh_host, ssh_port = self.api_key.split(":")
                 ssh_port = int(ssh_port)
             except ValueError:
-                raise ValueError("Invalid SSH connection string. Expected format: host:port")
-                
+                raise ValueError(
+                    "Invalid SSH connection string. Expected format: host:port"
+                )
+
             vlm_response, token_usage = run_ssh_llm_interleaved(
                 messages=planner_messages,
                 system=self.system_prompt,
@@ -133,32 +161,46 @@ class APIVLMPlanner:
                 ssh_port=ssh_port,
                 max_tokens=self.max_tokens,
             )
+        # Groq models (free tier, text-only)
+        elif self.model in ["llama-3.3-70b", "llama-3.1-8b", "llama-4-scout"]:
+            vlm_response, token_usage = run_groq_interleaved(
+                messages=planner_messages,
+                system=self.system_prompt,
+                llm=self.model,
+                api_key=self.api_key,
+                max_tokens=self.max_tokens,
+                temperature=0,
+            )
+            print(f"groq token usage: {token_usage}")
+            self.total_token_usage += token_usage
+            # Groq free tier - no cost
+            self.total_cost += 0
         else:
             raise ValueError(f"Model {self.model} not supported")
-            
+
         print(f"VLMPlanner response: {vlm_response}")
-        
+
         if self.print_usage:
-            print(f"VLMPlanner total token usage so far: {self.total_token_usage}. Total cost so far: $USD{self.total_cost:.5f}")
-        
+            print(
+                f"VLMPlanner total token usage so far: {self.total_token_usage}. Total cost so far: $USD{self.total_cost:.5f}"
+            )
+
         vlm_response_json = extract_data(vlm_response, "json")
 
         # vlm_plan_str = '\n'.join([f'{key}: {value}' for key, value in json.loads(response).items()])
         vlm_plan_str = ""
         for key, value in json.loads(vlm_response_json).items():
             if key == "Thinking":
-                vlm_plan_str += f'{value}'
+                vlm_plan_str += f"{value}"
             else:
-                vlm_plan_str += f'\n{key}: {value}'
-        
-        self.output_callback(f"{colorful_text_vlm}:\n{vlm_plan_str}", sender="bot")
-        
-        return vlm_response_json
+                vlm_plan_str += f"\n{key}: {value}"
 
+        self.output_callback(f"{colorful_text_vlm}:\n{vlm_plan_str}", sender="bot")
+
+        return vlm_response_json
 
     def _api_response_callback(self, response: APIResponse):
         self.api_response_callback(response)
-        
 
     def reformat_messages(self, messages: list):
         pass
@@ -205,9 +247,8 @@ IMPORTANT NOTES:
 3. Attach the text to Next Action, if there is text or any description for the button. 
 4. You should not include other actions, such as keyboard shortcuts.
 5. When the task is completed, you should say "Next Action": "None" in the json field.
-""" 
+"""
 
-    
 
 def _maybe_filter_to_n_most_recent_images(
     messages: list[BetaMessageParam],
@@ -262,7 +303,7 @@ def _message_filter_callback(messages):
     filtered_list = []
     try:
         for msg in messages:
-            if msg.get('role') in ['user']:
+            if msg.get("role") in ["user"]:
                 if not isinstance(msg["content"], list):
                     msg["content"] = [msg["content"]]
                 if isinstance(msg["content"][0], TextBlock):
@@ -271,7 +312,7 @@ def _message_filter_callback(messages):
                     filtered_list.append(msg["content"][0])  # User message
                 else:
                     print("[_message_filter_callback]: drop message", msg)
-                    continue                
+                    continue
 
             # elif msg.get('role') in ['assistant']:
             #     if isinstance(msg["content"][0], TextBlock):
@@ -286,12 +327,12 @@ def _message_filter_callback(messages):
             #         print("[_message_filter_callback]: drop message", msg)
             #         continue
             #     filtered_list.append(msg["content"][0])  # User message
-                
+
             else:
                 print("[_message_filter_callback]: drop message", msg)
                 continue
-            
+
     except Exception as e:
         print("[_message_filter_callback]: error", e)
-                
+
     return filtered_list

--- a/computer_use_demo/loop.py
+++ b/computer_use_demo/loop.py
@@ -1,6 +1,7 @@
 """
 Agentic sampling loop that calls the Anthropic API and local implementation of computer use tools.
 """
+
 import time
 import json
 from collections.abc import Callable
@@ -10,11 +11,13 @@ from anthropic import APIResponse
 from anthropic.types.beta import BetaContentBlock, BetaMessage, BetaMessageParam
 from computer_use_demo.tools import ToolResult
 
-from computer_use_demo.tools.colorful_text import colorful_text_showui, colorful_text_vlm
+from computer_use_demo.tools.colorful_text import (
+    colorful_text_showui,
+    colorful_text_vlm,
+)
 from computer_use_demo.tools.screen_capture import get_screenshot
 from computer_use_demo.gui_agent.llm_utils.oai import encode_image
 from computer_use_demo.tools.logger import logger
-
 
 
 class APIProvider(StrEnum):
@@ -24,6 +27,7 @@ class APIProvider(StrEnum):
     OPENAI = "openai"
     QWEN = "qwen"
     SSH = "ssh"
+    GROQ = "groq"
 
 
 PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
@@ -33,12 +37,13 @@ PROVIDER_TO_DEFAULT_MODEL_NAME: dict[APIProvider, str] = {
     APIProvider.OPENAI: "gpt-4o",
     APIProvider.QWEN: "qwen2vl",
     APIProvider.SSH: "qwen2-vl-2b",
+    APIProvider.GROQ: "llama-3.3-70b",
 }
 
 PLANNER_MODEL_CHOICES_MAPPING = {
     "claude-3-5-sonnet-20241022": "claude-3-5-sonnet-20241022",
     "gpt-4o": "gpt-4o",
-    "gpt-4o-mini": "gpt-4o-mini", 
+    "gpt-4o-mini": "gpt-4o-mini",
     "qwen2-vl-max": "qwen2-vl-max",
     "qwen2-vl-2b (local)": "qwen2-vl-2b-instruct",
     "qwen2-vl-7b (local)": "qwen2-vl-7b-instruct",
@@ -46,6 +51,10 @@ PLANNER_MODEL_CHOICES_MAPPING = {
     "qwen2.5-vl-7b (local)": "qwen2.5-vl-7b-instruct",
     "qwen2-vl-2b (ssh)": "qwen2-vl-2b (ssh)",
     "qwen2-vl-7b (ssh)": "qwen2-vl-7b (ssh)",
+    # Groq models (free tier, text-only - use with ShowUI actor)
+    "llama-3.3-70b (Groq)": "llama-3.3-70b",
+    "llama-3.1-8b (Groq)": "llama-3.1-8b",
+    "llama-4-scout (Groq)": "llama-4-scout",
 }
 
 
@@ -66,7 +75,7 @@ def sampling_loop_sync(
     selected_screen: int = 0,
     showui_max_pixels: int = 1344,
     showui_awq_4bit: bool = False,
-    ui_tars_url: str = ""
+    ui_tars_url: str = "",
 ):
     """
     Synchronous agentic sampling loop for the assistant/tool interaction of computer use.
@@ -75,39 +84,44 @@ def sampling_loop_sync(
     # ---------------------------
     # Initialize Planner
     # ---------------------------
-    
+
     if planner_model in PLANNER_MODEL_CHOICES_MAPPING:
         planner_model = PLANNER_MODEL_CHOICES_MAPPING[planner_model]
     else:
         raise ValueError(f"Planner Model {planner_model} not supported")
-    
+
     if planner_model == "claude-3-5-sonnet-20241022":
-        
         from computer_use_demo.gui_agent.planner.anthropic_agent import AnthropicActor
         from computer_use_demo.executor.anthropic_executor import AnthropicExecutor
-        
+
         # Register Actor and Executor
         actor = AnthropicActor(
-            model=planner_model, 
-            provider=actor_provider, 
-            system_prompt_suffix=system_prompt_suffix, 
-            api_key=api_key, 
+            model=planner_model,
+            provider=actor_provider,
+            system_prompt_suffix=system_prompt_suffix,
+            api_key=api_key,
             api_response_callback=api_response_callback,
             max_tokens=max_tokens,
             only_n_most_recent_images=only_n_most_recent_images,
-            selected_screen=selected_screen
+            selected_screen=selected_screen,
         )
 
         executor = AnthropicExecutor(
             output_callback=output_callback,
             tool_output_callback=tool_output_callback,
-            selected_screen=selected_screen
+            selected_screen=selected_screen,
         )
 
         loop_mode = "unified"
 
-    elif planner_model in ["gpt-4o", "gpt-4o-mini", "qwen2-vl-max"]:
-        
+    elif planner_model in [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "qwen2-vl-max",
+        "llama-3.3-70b",
+        "llama-3.1-8b",
+        "llama-4-scout",
+    ]:
         from computer_use_demo.gui_agent.planner.api_vlm_planner import APIVLMPlanner
 
         planner = APIVLMPlanner(
@@ -122,14 +136,19 @@ def sampling_loop_sync(
         loop_mode = "planner + actor"
 
     elif planner_model in ["qwen2-vl-2b-instruct", "qwen2-vl-7b-instruct"]:
-        
         import torch
-        from computer_use_demo.gui_agent.planner.local_vlm_planner import LocalVLMPlanner
-        if torch.cuda.is_available(): device = torch.device("cuda")
-        elif torch.backends.mps.is_available(): device = torch.device("mps")
-        else: device = torch.device("cpu") # support: 'cpu', 'mps', 'cuda'
+        from computer_use_demo.gui_agent.planner.local_vlm_planner import (
+            LocalVLMPlanner,
+        )
+
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+        else:
+            device = torch.device("cpu")  # support: 'cpu', 'mps', 'cuda'
         logger.info(f"Planner model {planner_model} inited on device: {device}.")
-        
+
         planner = LocalVLMPlanner(
             model=planner_model,
             provider=planner_provider,
@@ -138,10 +157,10 @@ def sampling_loop_sync(
             api_response_callback=api_response_callback,
             selected_screen=selected_screen,
             output_callback=output_callback,
-            device=device
+            device=device,
         )
         loop_mode = "planner + actor"
-        
+
     elif "ssh" in planner_model:
         planner = APIVLMPlanner(
             model=planner_model,
@@ -156,74 +175,75 @@ def sampling_loop_sync(
     else:
         logger.error(f"Planner Model {planner_model} not supported")
         raise ValueError(f"Planner Model {planner_model} not supported")
-        
 
     # ---------------------------
     # Initialize Actor, Executor
     # ---------------------------
     if actor_model == "ShowUI":
-        
         from computer_use_demo.executor.showui_executor import ShowUIExecutor
         from computer_use_demo.gui_agent.actor.showui_agent import ShowUIActor
+
         if showui_awq_4bit:
             showui_model_path = "./showui-2b-awq-4bit/"
         else:
             showui_model_path = "./showui-2b/"
-            
+
         import torch
-        if torch.cuda.is_available(): device = torch.device("cuda")
-        elif torch.backends.mps.is_available(): device = torch.device("mps")
-        else: device = torch.device("cpu") # support: 'cpu', 'mps', 'cuda'
+
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+        else:
+            device = torch.device("cpu")  # support: 'cpu', 'mps', 'cuda'
         logger.info(f"Actor model {actor_model} inited on device: {device}.")
 
         actor = ShowUIActor(
-            model_path=showui_model_path,  
-            device=device,  
-            split='desktop',  # 'desktop' or 'phone'
+            model_path=showui_model_path,
+            device=device,
+            split="desktop",  # 'desktop' or 'phone'
             selected_screen=selected_screen,
             output_callback=output_callback,
             max_pixels=showui_max_pixels,
-            awq_4bit=showui_awq_4bit
+            awq_4bit=showui_awq_4bit,
         )
-        
+
         executor = ShowUIExecutor(
             output_callback=output_callback,
             tool_output_callback=tool_output_callback,
-            selected_screen=selected_screen
+            selected_screen=selected_screen,
         )
 
     elif actor_model == "UI-TARS":
-        
         from computer_use_demo.executor.showui_executor import ShowUIExecutor
         from computer_use_demo.gui_agent.actor.uitars_agent import UITARS_Actor
-        
+
         actor = UITARS_Actor(
             ui_tars_url=ui_tars_url,
             output_callback=output_callback,
-            selected_screen=selected_screen
+            selected_screen=selected_screen,
         )
-        
+
         executor = ShowUIExecutor(
             output_callback=output_callback,
             tool_output_callback=tool_output_callback,
-            selected_screen=selected_screen
+            selected_screen=selected_screen,
         )
-        
+
     elif actor_model == "claude-3-5-sonnet-20241022":
         loop_mode = "unified"
 
     else:
         raise ValueError(f"Actor Model {actor_model} not supported")
 
-
     tool_result_content = None
     showui_loop_count = 0
-    
+
     logger.info(f"Start the message loop. User messages: {messages}")
 
     if loop_mode == "unified":
         # ------------------------------
-        # Unified loop: 
+        # Unified loop:
         # 1) repeatedly call actor -> executor -> check tool_result -> maybe end
         # ------------------------------
         while True:
@@ -239,16 +259,13 @@ def sampling_loop_sync(
                 return messages
 
             # If there is more tool content, treat that as user input
-            messages.append({
-                "content": tool_result_content,
-                "role": "user"
-            })
+            messages.append({"content": tool_result_content, "role": "user"})
 
     elif loop_mode == "planner + actor":
         # ------------------------------------------------------
-        # Planner + actor loop: 
+        # Planner + actor loop:
         # 1) planner => get next_action
-        # 2) If no next_action -> end 
+        # 2) If no next_action -> end
         # 3) Otherwise actor => executor
         # 4) repeat
         # ------------------------------------------------------
@@ -264,7 +281,9 @@ def sampling_loop_sync(
 
             # Step 3: Check if there are no further actions
             if not next_action or next_action in ("None", ""):
-                final_sc, final_sc_path = get_screenshot(selected_screen=selected_screen)
+                final_sc, final_sc_path = get_screenshot(
+                    selected_screen=selected_screen
+                )
                 final_image_b64 = encode_image(str(final_sc_path))
 
                 output_callback(
@@ -272,7 +291,7 @@ def sampling_loop_sync(
                         f"No more actions from {colorful_text_vlm}. End of task. Final State:\n"
                         f'<img src="data:image/png;base64,{final_image_b64}">'
                     ),
-                    sender="bot"
+                    sender="bot",
                 )
                 yield None
                 break
@@ -280,7 +299,7 @@ def sampling_loop_sync(
             # Step 4: Output an action message
             output_callback(
                 f"{colorful_text_vlm} sending action to {colorful_text_showui}:\n{next_action}",
-                sender="bot"
+                sender="bot",
             )
 
             # Step 5: Actor response
@@ -293,18 +312,17 @@ def sampling_loop_sync(
                 yield message
 
             # Step 7: Update conversation with embedding history of plan and actions
-            messages.append({
-                "role": "user",
-                "content": [
-                    "History plan:" + str(json.loads(vlm_response)),
-                    "History actions:" + str(actor_response["content"])
-                ]
-            })
-
-            logger.info(
-                f"End of loop. Total cost: $USD{planner.total_cost:.5f}"
+            messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        "History plan:" + str(json.loads(vlm_response)),
+                        "History actions:" + str(actor_response["content"]),
+                    ],
+                }
             )
 
+            logger.info(f"End of loop. Total cost: $USD{planner.total_cost:.5f}")
 
             # Increment loop counter
             showui_loop_count += 1


### PR DESCRIPTION
## Summary

This PR adds Groq as a free-tier API provider, enabling users to run the agent without any costs.

- Add `groq.py` with OpenAI-compatible API integration
- Add support for 4 free Groq models

## Available Models

| Model | Requests/Day | Tokens/Minute |
|-------|--------------|---------------|
| llama-3.3-70b-versatile | 1,000 | 12,000 |
| llama-3.1-8b-instant | 14,400 | 6,000 |
| llama-4-scout-17b | 1,000 | 30,000 |
| qwen3-32b | 1,000 | 6,000 |

See https://console.groq.com/docs/rate-limits for current limits.

## Important Note

Groq models are **text-only** (no vision support). For GUI automation tasks, use Groq as the planner with ShowUI as the actor - this is a powerful free-tier combination.

## Testing

Tested with Groq API and verified:
- API calls work correctly
- Model dropdown shows Groq options
- Provider selection works properly

## Related

- Groq Console: https://console.groq.com/
- Free tier documentation: https://console.groq.com/docs/rate-limits